### PR TITLE
Customer lists pagination

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,13 +51,6 @@
             this.$('.missing-fields-note').hide();
             this.setData();
             this.switchTo('loading');
-            /*this.getRecipients(listid).then(function(data) {
-              self.recipients = data.rows;
-              self.switchTo('confirmation', {
-                recipientCount: self.recipients.length,
-                data: this.data
-              });
-            });*/
             this.getRecipients(listid);
             this.disableNextButton(false);
           }
@@ -380,10 +373,6 @@
         this.viewId = data.view.id;
       }.bind(this));
     },
-
-    /*getRecipients: function(listid){
-      return this.ajax('customerListMemberships', listid);
-    },*/
 
     getRecipients: function(listid, nextPage){
       var self = this;


### PR DESCRIPTION
After we created the app, the customers lists APIs changed slightly and added pagination. That means our app was only ever creating up to 100 tickets for any given customer lists - we simply didn't account for pagination. This attempts to resolve that problem.

We may want to place an artificial limit in here - in other words actually restrict how many users we'll pull from a given CL (2000?). This PR doesn't address that. It also can take awhile simply to count recipients before the confirmation page is loaded. Luckily we have loading dots, but there's probably a better solution.  It's also entirely possible that my method of iteration (recursion) is crap for performance. This is why I'm doing a PR. So you can tell me this is a bad idea.

Other things worth noting:  This is my first ever real PR. This is my first time using recursion outside the college classroom. :dancer: (this may have taken me all afternoon)

cc @jespr 
