### PR TITLE
Maintain values on setup screen when going back from confirmation

### DIFF
--- a/app.js
+++ b/app.js
@@ -177,6 +177,7 @@
       var statusOptions;
       var priorityActive;
       var typeActive;
+      var activeListIDs = [];
 
       this.ajax('customerLists').then(function(customerListData){
         this.ajax('listTicketFields').then(function(fieldsData){
@@ -209,19 +210,41 @@
 
             var activeLists = this.findActiveViews(customerListData.user_views);
 
-            console.log("list id: " + this.selectedList);
+            for(var j=0; j< activeLists.length; j++){
+              activeListIDs.push({name: activeLists[j].title, value: activeLists[j].id});
+            }
 
             if(self.previousData){
               self.switchTo('main', {user_views:activeLists, fields:fieldsData.ticket_fields, priorities:priorityOptions, types:typeOptions, statuses:statusOptions, groupAssignees:memberships, hasPriority:priorityActive, hasType:typeActive, prevData:this.previousData, prevSubject:this.data.ticketData.subject, prevDesc:this.data.ticketData.comment.body, prevTags:this.originalTags, prevName:this.data.campaignName, prevList:this.selectedList});
-              self._renderSelect('status', statusOptions, this.$('.statuses'), { name: this.I18n.t('form.statusnew'), value: 'new' });
-              self._renderSelect('type', typeOptions, this.$('.types'), {value: this.data.ticketData.type});
-              self._renderSelect('priority', priorityOptions, this.$('.priorities'), {value: this.data.ticketData.priority});
+              self._renderSelect('customer-list', activeListIDs, this.$('.user_views'), true, {value: this.selectedList});
             }
             else{
               self.switchTo('main', {user_views:activeLists, fields:fieldsData.ticket_fields, priorities:priorityOptions, types:typeOptions, statuses:statusOptions, groupAssignees:memberships, hasPriority:priorityActive, hasType:typeActive, prevData:this.previousData});
-              self._renderSelect('status', statusOptions, this.$('.statuses'), { name: this.I18n.t('form.statusnew'), value: 'new' });
-              self._renderSelect('type', typeOptions, this.$('.types'));
-              self._renderSelect('priority', priorityOptions, this.$('.priorities'));
+              self._renderSelect('customer-list', activeListIDs, this.$('.user_views'), true);
+            }
+
+            // Set up for Status
+            if((self.previousData && this.data.ticketData.status == "new") || !self.previousData){
+              self._renderSelect('status', statusOptions, this.$('.statuses'), true, { name: this.I18n.t('form.statusnew'), value: 'new' });
+            }
+            else{
+              self._renderSelect('status', statusOptions, this.$('.statuses'), true, { value: this.data.ticketData.status });
+            }
+            
+            // Set up for Ticket Type
+            if(self.previousData && this.data.ticketData.type != ''){
+              self._renderSelect('type', typeOptions, this.$('.types'), false, {value: this.data.ticketData.type});
+            }
+            else{
+              self._renderSelect('type', typeOptions, this.$('.types'), false);
+            }
+
+            // Set up for Priority
+            if(self.previousData && this.data.ticketData.priority != ''){
+              self._renderSelect('priority', priorityOptions, this.$('.priorities'), false, {value: this.data.ticketData.priority});
+            }
+            else{
+              self._renderSelect('priority', priorityOptions, this.$('.priorities'), false);
             }
 
              // self._renderComboSelect('assignee', memberships, this.$('.assignees'));
@@ -435,14 +458,18 @@
       this.$('.still_questions').addClass('selected');
     },
 
-    _renderSelect: function(name, options, $el, defaultValue) {
+    _renderSelect: function(name, options, $el, required, defaultValue) {
       if (!$el.length) {
         return;
       }
 
       if (defaultValue !== undefined) {
         options.unshift(defaultValue);
-      } else {
+      } 
+      else if(required){
+        // basically do nothing - leave it alone
+      }
+      else {
         options.unshift({name: '-', value: ''});
       }
 
@@ -475,7 +502,6 @@
         $el.find('select').zdComboSelectMenu('setValue', this.fields[name]);
       }
     }
-
 
   };
 

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -4,23 +4,9 @@
       <h3>{{t "form.customer_list"}}*</h3>
       <p class="instructions">{{t "instructions.customer_list"}}</p>
     </div>
-    {{#if prevData}}
-      <div class="question-field">
-        <select name="customer-list" id="customer-list" value="{{prevList}}">
-          {{#each user_views}}
-            <option value="{{id}}">{{title}}</option>
-          {{/each}}
-        </select>
-      </div>
-    {{else}}
-      <div class="question-field">
-        <select name="customer-list" id="customer-list">
-          {{#each user_views}}
-            <option value="{{id}}">{{title}}</option>
-          {{/each}}
-        </select>
+    <div class="question-field">
+      <div class="user_views"></div>
     </div>
-    {{/if}}
   </div>
   <div class="question">
     <div class="question-label">


### PR DESCRIPTION
Adds support to keep previous values populated on setup page after viewing the confirmation screen.
- All fields are supported EXCEPT group & assignee. That's a cluster for another day
- If you hit previous twice and go all the way back to the onboarding screen, all values will be reset
- Customer list drop-down now uses the renderSelect method to be consistent with other drop-downs
- Added param to renderSelect method to allow you to designate a field as required (bypasses adding the "-" to the top of the list)

cc @jespr 
