### PR TITLE
Reset recipients array on previous

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,6 +66,7 @@
       if (this.currentView === 0) { return; }
       this.currentView -= 1;
       this.previousData = true;
+      this.recipients.length = 0;
       this.goToTemplate();
     },
 


### PR DESCRIPTION
Fixes a nasty bug there the recipients array kept duplicating itself if
you went from the Measure Twice Cut Once screen back to the set up
screen and forward again.
