### PR TITLE
Prevent customer list sampling

### DIFF
--- a/app.js
+++ b/app.js
@@ -155,6 +155,7 @@
           return{
             url: '/api/v2/user_views/' + id + '/execute.json',
             type: 'GET',
+            data: { sampling: false },
             dataType: 'json'
           };
         }


### PR DESCRIPTION
Customer lists are sampled by default for any account with a lot of users.  This means that only a random set of users will ever receive a proactive ticket.  The query param should make sure it gets all the users.

![](https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcS4LWdR1Tb8AGngKU47LDGRtVLFDGA5bgZb1rS8oYyr6sAQFaFk0SsTQQ)

I don't know who to tag so I'm going to tag some people.

@dpawluk @jespr @eboyle 

