### PR TITLE
Ability to create Invisible tickets

### DIFF
--- a/app.js
+++ b/app.js
@@ -249,7 +249,7 @@
               self._renderSelect('priority', priorityOptions, this.$('.priorities'), false);
             }
 
-            self._renderSelect('is_public', [ { name: 'Public reply', value: true }, { name: 'Internal note', value: false } ], this.$('.is_public'), true, { value: (this.data.ticketData ? this.data.ticketData.is_public : true) });
+            self._renderSelect('is_public', [ { name: this.I18n.t("form.publicreply"), value: true }, { name: this.I18n.t("form.internalnote"), value: false } ], this.$('.is_public'), true, { value: (this.data.ticketData ? this.data.ticketData.is_public : true) });
 
              // self._renderComboSelect('assignee', memberships, this.$('.assignees'));
           });

--- a/app.js
+++ b/app.js
@@ -334,7 +334,8 @@
           ticket: {
             subject: self.data.ticketData.subject,
             comment: {
-              body: self.data.ticketData.comment.body
+              body: self.data.ticketData.comment.body,
+              public: self.data.ticketData.is_public
             },
             tags: self.data.ticketData.tags,
             requester_id: recipient.id,
@@ -343,8 +344,7 @@
             type: self.data.ticketData.type,
             group_id: self.data.ticketData.group_id,
             assignee_id: self.data.ticketData.assignee_id,
-            submitter_id: this.currentUser().id(),
-            is_public: self.data.ticketData.is_public
+            submitter_id: this.currentUser().id()
           }
         };
         self.ajax('createTicket', newData);

--- a/app.js
+++ b/app.js
@@ -249,6 +249,8 @@
               self._renderSelect('priority', priorityOptions, this.$('.priorities'), false);
             }
 
+            self._renderSelect('is_public', [ { name: 'Public reply', value: true }, { name: 'Internal note', value: false } ], this.$('.is_public'), true, { value: (this.data.ticketData ? this.data.ticketData.is_public : true) });
+
              // self._renderComboSelect('assignee', memberships, this.$('.assignees'));
           });
         });
@@ -267,7 +269,8 @@
     },
 
     setData: function() {
-      var subject = this.getField('subject'),
+      var is_public = this.getField('is_public') === 'true',
+          subject = this.getField('subject'),
           tags = this.getTagsArray(),
           status = this.getField('status'),
           type = this.getField('type'),
@@ -313,7 +316,8 @@
           type: type,
           priority: priority,
           group_id: group,
-          assignee_id: assignee
+          assignee_id: assignee,
+          is_public: is_public
         }
       };
     },
@@ -339,7 +343,8 @@
             type: self.data.ticketData.type,
             group_id: self.data.ticketData.group_id,
             assignee_id: self.data.ticketData.assignee_id,
-            submitter_id: this.currentUser().id()
+            submitter_id: this.currentUser().id(),
+            is_public: self.data.ticketData.is_public
           }
         };
         self.ajax('createTicket', newData);

--- a/templates/confirmation.hdbs
+++ b/templates/confirmation.hdbs
@@ -10,6 +10,14 @@
   <div class="data-container">
     <div class="column">
       <div class="data">
+        <strong>{{t "confirmation.is_public"}}</strong>
+        {{#if this.data.ticketData.is_public}}
+          Public reply
+        {{else}}
+          Internal note
+        {{/if}}
+      </div>
+      <div class="data">
         <strong>{{t "confirmation.subject"}}</strong> {{this.data.ticketData.subject}}
       </div>
       <div class="data">

--- a/templates/confirmation.hdbs
+++ b/templates/confirmation.hdbs
@@ -10,14 +10,6 @@
   <div class="data-container">
     <div class="column">
       <div class="data">
-        <strong>{{t "confirmation.is_public"}}</strong>
-        {{#if this.data.ticketData.is_public}}
-          Public reply
-        {{else}}
-          Internal note
-        {{/if}}
-      </div>
-      <div class="data">
         <strong>{{t "confirmation.subject"}}</strong> {{this.data.ticketData.subject}}
       </div>
       <div class="data">
@@ -44,6 +36,14 @@
       </div>
     </div>
     <div class="column">
+      <div class="data">
+        <strong>{{t "confirmation.is_public"}}</strong>
+        {{#if this.data.ticketData.is_public}}
+          {{t "form.publicreply"}}
+        {{else}}
+          {{t "form.internalnote"}}
+        {{/if}}
+      </div>
       <div class="data">
         <div class="descriptionfield">
           <strong>{{t "confirmation.description"}}</strong> {{this.data.ticketData.comment.body}}

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -32,6 +32,10 @@
       <p class="instructions">{{t "instructions.proactive_ticket_fields"}} <a href="https://support.zendesk.com/entries/62082233" target="_blank">{{t "instructions.this_user_guide"}}</a>
 </p>
     </div>
+    <div class="question-field">
+      <label>{{t "form.is_public"}}</label>
+      <div class="is_public"></div>
+    </div>
     {{#if prevData}}
       <div class="question-field">
           <label>{{t "form.subject"}}</label>

--- a/templates/main.hdbs
+++ b/templates/main.hdbs
@@ -32,10 +32,6 @@
       <p class="instructions">{{t "instructions.proactive_ticket_fields"}} <a href="https://support.zendesk.com/entries/62082233" target="_blank">{{t "instructions.this_user_guide"}}</a>
 </p>
     </div>
-    <div class="question-field">
-      <label>{{t "form.is_public"}}</label>
-      <div class="is_public"></div>
-    </div>
     {{#if prevData}}
       <div class="question-field">
           <label>{{t "form.subject"}}</label>
@@ -87,13 +83,17 @@
       <label>{{t "form.status"}}</label>
       <div class="statuses"></div>
     </div>
+      <div class="question-field">
+      <label>{{t "form.is_public"}}</label>
+      <div class="is_public"></div>
+    </div>
     {{#if prevData}}
-      <div class="question-field description-field">
+      <div class="question-field">
         <label>{{t "form.description"}}</label>
         <textarea name="description" id="description" rows="12">{{prevDesc}}</textarea>
       </div>
     {{else}}
-      <div class="question-field description-field">
+      <div class="question-field">
         <label>{{t "form.description"}}</label>
         <textarea name="description" id="description" rows="12">{{t "form.defaultdescription1"}}&#13;&#10;&#13;{{t "form.defaultdescription2"}}</textarea>
       </div>

--- a/translations/en.json
+++ b/translations/en.json
@@ -23,6 +23,10 @@
         "value": "Create your proactive ticket",
         "title": "Proactive ticket fields"
     },
+    "is_public": {
+        "value": "Public",
+        "title": "Public label"
+    },
     "subject": {
         "value": "Subject",
         "title": "Subject label"
@@ -214,8 +218,12 @@
         "title": "Copy 1 for confirmation page"
     },
     "copy2": {
-        "value": "customers. They will receive an email notification with the below ticket details.",
+        "value": "customers.",
         "title": "Copy 2 for confirmation page"
+    },
+    "is_public": {
+      "value":"Public",
+      "title":"Public label"
     },
     "subject": {
       "value":"SUBJECT",

--- a/translations/en.json
+++ b/translations/en.json
@@ -24,7 +24,7 @@
         "title": "Proactive ticket fields"
     },
     "is_public": {
-        "value": "Public",
+        "value": "Visibility",
         "title": "Public label"
     },
     "subject": {
@@ -86,6 +86,14 @@
     "defaultdescription2": {
         "value": "This ticket was created on your behalf.",
         "title": "Default description text part 2"
+    },
+    "internalnote": {
+        "value": "Internal note",
+        "title": "Private ticket"
+    },
+    "publicreply": {
+        "value": "Public reply",
+        "title": "Public ticket"
     }
 },
 "instructions": {
@@ -222,7 +230,7 @@
         "title": "Copy 2 for confirmation page"
     },
     "is_public": {
-      "value":"Public",
+      "value":"VISIBILITY",
       "title":"Public label"
     },
     "subject": {


### PR DESCRIPTION
Adding a new field to choose whether the first ticket comment is a Public reply or an Internal note (new feature in Zendesk). Proactive Tickets is a great way to create these invisible tickets.